### PR TITLE
Callback types

### DIFF
--- a/packages/debounce/package.json
+++ b/packages/debounce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-hook/debounce",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "homepage": "https://github.com/jaredLunde/react-hook/tree/master/packages/debounce#readme",
   "repository": "github:jaredLunde/react-hook",
   "bugs": "https://github.com/jaredLunde/react-hook/issues",

--- a/packages/debounce/src/index.test.ts
+++ b/packages/debounce/src/index.test.ts
@@ -2,9 +2,9 @@ import {renderHook, act} from '@testing-library/react-hooks'
 import {useDebounce, useDebounceCallback} from './index'
 import * as raf from 'raf'
 
-const renderDebounce = (fn, ...args: any[]): any =>
-  renderHook(() => useDebounce(fn, ...args))
-const renderDebounceCallback = (fn, ...args: any[]): any =>
+const renderDebounce = (callback, ...args) =>
+  renderHook(() => useDebounce(callback, ...args))
+const renderDebounceCallback = (fn, ...args) =>
   renderHook(() => useDebounceCallback(fn, ...args))
 
 describe('debounce', () => {

--- a/packages/debounce/src/index.ts
+++ b/packages/debounce/src/index.ts
@@ -1,12 +1,12 @@
-import {useCallback, useEffect, useState, useRef} from 'react'
-import {requestTimeout, clearRequestTimeout} from '@essentials/request-timeout'
+import { useCallback, useEffect, useState, useRef, Dispatch, SetStateAction } from 'react'
+import {requestTimeout, clearRequestTimeout, RequestTimeoutHandle} from '@essentials/request-timeout'
 
-export const useDebounceCallback = (
-  callback: (...args: any[]) => any,
+export const useDebounceCallback = <CallbackArgs extends any[]>(
+  callback: (...args: CallbackArgs) => any,
   wait = 100,
   leading = false
-): ((...args: any[]) => any) => {
-  const timeout = useRef(null)
+): ((...args: CallbackArgs) => void) => {
+  const timeout = useRef<RequestTimeoutHandle | null>(null)
 
   // cleans up pending timeouts when the function changes
   useEffect(
@@ -20,11 +20,9 @@ export const useDebounceCallback = (
   )
 
   return useCallback(
-    function() {
+    function(...args) {
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const self = this
-      // eslint-disable-next-line prefer-rest-params
-      const args = arguments
 
       if (timeout.current === null && leading) callback.apply(self, args)
       else if (timeout.current !== null) clearRequestTimeout(timeout.current)
@@ -38,11 +36,11 @@ export const useDebounceCallback = (
   )
 }
 
-export const useDebounce = (
-  initialState: any,
+export const useDebounce = <State>(
+  initialState: State | (() => State),
   wait?: number,
   leading?: boolean
-): any[] => {
+): [State, Dispatch<SetStateAction<State>>] => {
   const [state, setState] = useState(initialState)
   return [state, useDebounceCallback(setState, wait, leading)]
 }

--- a/packages/throttle/package.json
+++ b/packages/throttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-hook/throttle",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "homepage": "https://github.com/jaredLunde/react-hook/tree/master/packages/throttle#readme",
   "repository": "github:jaredLunde/react-hook",
   "bugs": "https://github.com/jaredLunde/react-hook/issues",

--- a/packages/throttle/src/index.test.ts
+++ b/packages/throttle/src/index.test.ts
@@ -2,9 +2,9 @@ import {renderHook, act} from '@testing-library/react-hooks'
 import {useThrottle, useThrottleCallback} from './index'
 import * as raf from 'raf'
 
-const renderThrottle = (callback, ...args): any =>
+const renderThrottle = (callback, ...args) =>
   renderHook(() => useThrottle(callback, ...args))
-const renderThrottleCallback = (callback, ...args): any =>
+const renderThrottleCallback = (callback, ...args) =>
   renderHook(() => useThrottleCallback(callback, ...args))
 
 describe('throttle', () => {

--- a/packages/throttle/src/index.ts
+++ b/packages/throttle/src/index.ts
@@ -1,14 +1,14 @@
-import {useEffect, useCallback, useState, useRef} from 'react'
-import {requestTimeout, clearRequestTimeout} from '@essentials/request-timeout'
+import { useEffect, useCallback, useState, useRef, Dispatch, SetStateAction } from 'react'
+import {requestTimeout, clearRequestTimeout, RequestTimeoutHandle} from '@essentials/request-timeout'
 
-export const useThrottleCallback = (
-  callback: (...args: any[]) => any,
+export const useThrottleCallback = <CallbackArgs extends any[]>(
+  callback: (...args: CallbackArgs) => any,
   fps = 30,
   leading = false
-): ((...args: any[]) => any) => {
-  const nextTimeout = useRef(null),
-    tailTimeout = useRef(null),
-    calledLeading = useRef(false),
+): ((...args: CallbackArgs) => void) => {
+  const nextTimeout = useRef<RequestTimeoutHandle | null>(null),
+    tailTimeout = useRef<RequestTimeoutHandle | null>(null),
+    calledLeading = useRef<boolean>(false),
     wait = 1000 / fps
 
   // cleans up pending timeouts when the function changes
@@ -30,11 +30,9 @@ export const useThrottleCallback = (
   )
 
   return useCallback(
-    function() {
+    function(...args) {
       // eslint-disable-next-line @typescript-eslint/no-this-alias
-      const self = this,
-        // eslint-disable-next-line prefer-rest-params
-        args = arguments
+      const self = this;
 
       if (nextTimeout.current === null) {
         const next = (): void => {
@@ -65,12 +63,12 @@ export const useThrottleCallback = (
   )
 }
 
-export const useThrottle = (
-  initialState: any,
+export const useThrottle = <State>(
+  initialState: State | (() => State),
   fps?: number,
   leading?: boolean
-): any[] => {
-  const [state, setState] = useState(initialState)
+): [State, Dispatch<SetStateAction<State>>] => {
+  const [state, setState] = useState<State>(initialState);
   return [state, useThrottleCallback(setState, fps, leading)]
 }
 


### PR DESCRIPTION
Hey!

Thanks for such great hooks!

I'm going to use your hooks in our projects, but some missing types make me unhappy, so I'm glad to help the project with PR;

Changes in the PR:
1. Keep callback args types, to do not lose them after passing my callback to the hooks
2. Use same types from `React.useState()`