### PR TITLE
Refactor: pass options instead of arguments list to `throttle` and `debounce` hooks

### DIFF
--- a/packages/debounce/README.md
+++ b/packages/debounce/README.md
@@ -35,24 +35,30 @@ const Component = props => {
   const [value, setValue] = useDebounce('initialValue')
 }
 
-const useMyCallback = (initialState, wait, leading) => {
+const useMyCallback = (initialState, {wait, leading}) => {
   // this is the same code useDebounce() uses to debounce setState
   const [state, setState] = useState(initialState)
-  return [state, useDebounceCallback(setState, wait, leading)]
+  return [state, useDebounceCallback(setState, {wait, leading})]
 }
 ```
 
 ## API
 
-### `useDebounce(initialState: any, wait?: number, leading?: boolean)`
+### `useDebounce(initialState: any, options?: {wait?: number, leading?: boolean})`
 
 #### Options
 
-| Property     | Type      | Default | Description                                                                                                                |
-| ------------ | --------- | ------- | -------------------------------------------------------------------------------------------------------------------------- |
-| initialState | `any`     |         | The initial state stored in `useState`                                                                                     |
-| wait         | `number`  | `100`   | Defines the amount of time you want `setState` to wait after the last received action before executing                     |
-| leading      | `boolean` | `false` | Calls `setState` on the leading edge (right away). When `false`, `setState` will not be called until the next frame is due |
+| Property        | Type              | Default | Description                            |
+| --------------- | ----------------- | ------- | -------------------------------------- |
+| initialState    | `any`             |         | The initial state stored in `useState` |
+| debounceOptions | `DebounceOptions` |         | Defines debouncing options             |
+
+##### DebounceOptions
+
+| Key     | Type      | Default | Description                                                                                                               |
+| ------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
+| wait    | `number`  | `100`   | Defines the amount of time you want `setState` to wait after the last received action before executing                    |
+| leading | `boolean` | `false` | Calls `setState` on the leading edge (right away). When `false` `setState` will not be called until the next frame is due |
 
 #### Returns `[state, setState]`
 
@@ -63,15 +69,21 @@ const useMyCallback = (initialState, wait, leading) => {
 
 ---
 
-### `useDebounceCallback(callback: Function, wait?: number, leading?: boolean)`
+### `useDebounceCallback(callback: Function, options?: {wait?: number, leading?: boolean})`
 
 #### Options
 
-| Property | Type       | Default | Description                                                                                                                |
-| -------- | ---------- | ------- | -------------------------------------------------------------------------------------------------------------------------- |
-| callback | `Function` |         | This is the callback you want to debounce                                                                                  |
-| wait     | `number`   | `100`   | Defines the amount of time you want `setState` to wait after the last received action before executing                     |
-| leading  | `boolean`  | `false` | Calls `setState` on the leading edge (right away). When `false`, `setState` will not be called until the next frame is due |
+| Property        | Type              | Default | Description                               |
+| --------------- | ----------------- | ------- | ----------------------------------------- |
+| callback        | `Function`        |         | This is the callback you want to debounce |
+| debounceOptions | `DebounceOptions` |         | Defines debouncing options                |
+
+##### DebounceOptions
+
+| Key     | Type      | Default | Description                                                                                                               |
+| ------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
+| wait    | `number`  | `100`   | Defines the amount of time you want `setState` to wait after the last received action before executing                    |
+| leading | `boolean` | `false` | Calls `setState` on the leading edge (right away). When `false` `setState` will not be called until the next frame is due |
 
 #### Returns `debouncedCallback`
 

--- a/packages/debounce/package.json
+++ b/packages/debounce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-hook/debounce",
-  "version": "1.0.11",
+  "version": "2.0.0",
   "homepage": "https://github.com/jaredLunde/react-hook/tree/master/packages/debounce#readme",
   "repository": "github:jaredLunde/react-hook",
   "bugs": "https://github.com/jaredLunde/react-hook/issues",

--- a/packages/debounce/src/index.test.ts
+++ b/packages/debounce/src/index.test.ts
@@ -1,18 +1,18 @@
 import {renderHook, act} from '@testing-library/react-hooks'
-import {useDebounce, useDebounceCallback} from './index'
+import {DebounceOptions, useDebounce, useDebounceCallback} from './index'
 import * as raf from 'raf'
 
-const renderDebounce = (callback, ...args) =>
-  renderHook(() => useDebounce(callback, ...args))
-const renderDebounceCallback = (fn, ...args) =>
-  renderHook(() => useDebounceCallback(fn, ...args))
+const renderDebounce = (callback, options: DebounceOptions) =>
+  renderHook(() => useDebounce(callback, options))
+const renderDebounceCallback = (fn, options: DebounceOptions) =>
+  renderHook(() => useDebounceCallback(fn, options))
 
 describe('debounce', () => {
   beforeEach(raf.reset)
 
   test('callback [30ms]', () => {
     const cb = jest.fn()
-    const {result} = renderDebounceCallback(cb, 30)
+    const {result} = renderDebounceCallback(cb, {wait: 30})
     for (let i = 0; i < 30; i++) act(result.current)
     act(() => raf.step({count: 60 * 30}))
     for (let i = 0; i < 30; i++) act(result.current)
@@ -22,7 +22,7 @@ describe('debounce', () => {
 
   test('callback [60ms]', () => {
     const cb = jest.fn()
-    const {result} = renderDebounceCallback(cb, 60)
+    const {result} = renderDebounceCallback(cb, {wait: 60})
     for (let i = 0; i < 60; i++) act(result.current)
     act(() => raf.step({count: 60 * 30}))
     for (let i = 0; i < 60; i++) act(result.current)
@@ -32,7 +32,7 @@ describe('debounce', () => {
 
   test('callback leading', () => {
     const cb = jest.fn()
-    const {result} = renderDebounceCallback(cb, 30, true)
+    const {result} = renderDebounceCallback(cb, {wait: 30, leading: true})
 
     for (let i = 0; i < 30; i++) act(result.current)
     // add 30ms
@@ -46,7 +46,7 @@ describe('debounce', () => {
   })
 
   test('value [60ms]', () => {
-    const {result} = renderDebounce(1, 60)
+    const {result} = renderDebounce(1, {wait: 60})
 
     act(() => result.current[1](2))
     expect(result.current[0]).toBe(1)
@@ -58,7 +58,7 @@ describe('debounce', () => {
   })
 
   test('value [<60ms]', () => {
-    const {result} = renderDebounce(1, 60)
+    const {result} = renderDebounce(1, {wait: 60})
 
     act(() => result.current[1](2))
     expect(result.current[0]).toBe(1)
@@ -74,7 +74,7 @@ describe('debounce', () => {
   })
 
   test('value leading', () => {
-    const {result} = renderDebounce(1, 60, true)
+    const {result} = renderDebounce(1, {wait: 60, leading: true})
     act(() => result.current[1](2))
     expect(result.current[0]).toBe(2) // leading
     act(() => result.current[1](3))

--- a/packages/debounce/src/index.ts
+++ b/packages/debounce/src/index.ts
@@ -12,11 +12,15 @@ import {
   RequestTimeoutHandle,
 } from '@essentials/request-timeout'
 
+export interface DebounceOptions {
+  wait?: number
+  leading?: boolean
+}
 export const useDebounceCallback = <CallbackArgs extends any[]>(
   callback: (...args: CallbackArgs) => any,
-  wait = 100,
-  leading = false
+  options: DebounceOptions = {},
 ): ((...args: CallbackArgs) => void) => {
+  const {leading = false, wait = 100} = options
   const timeout = useRef<RequestTimeoutHandle | null>(null)
 
   // cleans up pending timeouts when the function changes
@@ -49,11 +53,10 @@ export const useDebounceCallback = <CallbackArgs extends any[]>(
 
 export const useDebounce = <State>(
   initialState: State | (() => State),
-  wait?: number,
-  leading?: boolean
+  options: DebounceOptions = {},
 ): [State, Dispatch<SetStateAction<State>>] => {
   const [state, setState] = useState(initialState)
-  return [state, useDebounceCallback(setState, wait, leading)]
+  return [state, useDebounceCallback(setState, options)]
 }
 
 export default useDebounce

--- a/packages/throttle/README.md
+++ b/packages/throttle/README.md
@@ -35,10 +35,10 @@ const Component = props => {
   const [value, setValue] = useThrottle('initialValue')
 }
 
-const useMyCallback = (initialState, wait, leading) => {
+const useMyCallback = (initialState, {fps, leading}) => {
   // this is the same code useThrottle() uses to throttle setState
   const [state, setState] = useState(initialState)
-  return [state, useThrottleCallback(setState, wait, leading)]
+  return [state, useThrottleCallback(setState, {fps, leading})]
 }
 ```
 
@@ -48,11 +48,18 @@ const useMyCallback = (initialState, wait, leading) => {
 
 #### Options
 
-| Property     | Type      | Default | Description                                                                                                                |
-| ------------ | --------- | ------- | -------------------------------------------------------------------------------------------------------------------------- |
-| initialState | `any`     |         | The initial state stored in `useState`                                                                                     |
-| fps          | `number`  | `30`    | Defines the rate in frames per second with which `setState` is invoked with new state                                      |
-| leading      | `boolean` | `false` | Calls `setState` on the leading edge (right away). When `false`, `setState` will not be called until the next frame is due |
+| Property        | Type              | Default | Description                            |
+| --------------- | ----------------- | ------- | -------------------------------------- |
+| initialState    | `any`             |         | The initial state stored in `useState` |
+| throttleOptions | `ThrottleOptions` |         | Defines throttling options             |
+
+##### ThrottleOptions
+
+| Key     | Type      | Default | Description                                                                                                                |
+| ------- | --------- | ------- | -------------------------------------------------------------------------------------------------------------------------- |
+| fps     | `number`  | `30`    | Defines the rate in frames per second with which `setState` is invoked with new state.                                     |
+| wait    | `number`  |         |                                                                                                                            |
+| leading | `boolean` | `false` | Calls `setState` on the leading edge (right away). When `false`, `setState` will not be called until the next frame is due |
 
 #### Returns `[state, setState]`
 
@@ -67,11 +74,18 @@ const useMyCallback = (initialState, wait, leading) => {
 
 #### Options
 
-| Property | Type       | Default | Description                                                                                                                |
-| -------- | ---------- | ------- | -------------------------------------------------------------------------------------------------------------------------- |
-| callback | `Function` |         | This is the callback you want to throttle                                                                                  |
-| fps      | `number`   | `30`    | Defines the rate in frames per second with which `setState` is invoked with new state                                      |
-| leading  | `boolean`  | `false` | Calls `setState` on the leading edge (right away). When `false`, `setState` will not be called until the next frame is due |
+| Property        | Type              | Default | Description                               |
+| --------------- | ----------------- | ------- | ----------------------------------------- |
+| callback        | `Function`        |         | This is the callback you want to throttle |
+| throttleOptions | `ThrottleOptions` |         | Defines throttling options                |
+
+##### ThrottleOptions
+
+| Key     | Type      | Default | Description                                                                                                                |
+| ------- | --------- | ------- | -------------------------------------------------------------------------------------------------------------------------- |
+| fps     | `number`  | `30`    | Defines the rate in frames per second with which `setState` is invoked with new state.                                     |
+| wait    | `number`  |         |                                                                                                                            |
+| leading | `boolean` | `false` | Calls `setState` on the leading edge (right away). When `false`, `setState` will not be called until the next frame is due |
 
 #### Returns `throttledCallback`
 

--- a/packages/throttle/package.json
+++ b/packages/throttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-hook/throttle",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "homepage": "https://github.com/jaredLunde/react-hook/tree/master/packages/throttle#readme",
   "repository": "github:jaredLunde/react-hook",
   "bugs": "https://github.com/jaredLunde/react-hook/issues",

--- a/packages/throttle/src/index.test.ts
+++ b/packages/throttle/src/index.test.ts
@@ -1,18 +1,18 @@
 import {renderHook, act} from '@testing-library/react-hooks'
-import {useThrottle, useThrottleCallback} from './index'
+import {ThrottleOptions, useThrottle, useThrottleCallback} from './index'
 import * as raf from 'raf'
 
-const renderThrottle = (callback, ...args) =>
-  renderHook(() => useThrottle(callback, ...args))
-const renderThrottleCallback = (callback, ...args) =>
-  renderHook(() => useThrottleCallback(callback, ...args))
+const renderThrottle = (callback, options?: ThrottleOptions) =>
+  renderHook(() => useThrottle(callback, options))
+const renderThrottleCallback = (callback, options?: ThrottleOptions) =>
+  renderHook(() => useThrottleCallback(callback, options))
 
 describe('throttle', () => {
   beforeEach(raf.reset)
 
   test('callback [30fps]', () => {
     const cb = jest.fn()
-    const {result} = renderThrottleCallback(cb, 30)
+    const {result} = renderThrottleCallback(cb, {fps: 30})
     for (let i = 0; i < 30; i++) act(result.current)
     act(() => raf.step({count: 1, time: 1000 / 30}))
     for (let i = 0; i < 30; i++) act(result.current)
@@ -20,9 +20,19 @@ describe('throttle', () => {
     expect(cb).toHaveBeenCalledTimes(4) // throttled + tails
   })
 
+  test('callback [30ms]', () => {
+    const cb = jest.fn()
+    const {result} = renderThrottleCallback(cb, {wait: 30})
+    for (let i = 0; i < 30; i++) act(result.current)
+    act(() => raf.step({count: 1, time: 30}))
+    for (let i = 0; i < 30; i++) act(result.current)
+    act(() => raf.step({count: 1, time: 30}))
+    expect(cb).toHaveBeenCalledTimes(4) // throttled + tails
+  })
+
   test('callback [60fps]', () => {
     const cb = jest.fn()
-    const {result} = renderThrottleCallback(cb, 60)
+    const {result} = renderThrottleCallback(cb, {fps: 60})
     for (let i = 0; i < 60; i++) act(result.current)
     act(() => raf.step({count: 1, time: 1000 / 60}))
     for (let i = 0; i < 60; i++) act(result.current)
@@ -32,7 +42,7 @@ describe('throttle', () => {
 
   test('callback leading', () => {
     const cb = jest.fn()
-    const {result} = renderThrottleCallback(cb, 30, true)
+    const {result} = renderThrottleCallback(cb, {fps: 30, leading: true})
     for (let i = 0; i < 30; i++) act(result.current)
     act(() => raf.step({count: 1, time: 1000 / 30}))
     for (let i = 0; i < 30; i++) act(result.current)
@@ -41,7 +51,7 @@ describe('throttle', () => {
   })
 
   test('value', () => {
-    const {result} = renderThrottle(1, 60)
+    const {result} = renderThrottle(1, {fps: 60})
     act(() => result.current[1](2))
     expect(result.current[0]).toBe(1)
     act(() => result.current[1](3))
@@ -50,7 +60,7 @@ describe('throttle', () => {
   })
 
   test('value leading', () => {
-    const {result} = renderThrottle(1, 60, true)
+    const {result} = renderThrottle(1, {fps: 60, leading: true})
     act(() => result.current[1](2))
     expect(result.current[0]).toBe(2) // leading
     act(() => result.current[1](3))

--- a/packages/throttle/src/index.ts
+++ b/packages/throttle/src/index.ts
@@ -26,10 +26,10 @@ export const useThrottleCallback = <CallbackArgs extends any[]>(
   callback: (...args: CallbackArgs) => any,
   options: ThrottleOptions = {}
 ): ((...args: CallbackArgs) => void) => {
-  const {leading = false} = options
-  const fpsOption = options.fps ?? 30
-  const wait = options.wait ?? 1000 / fpsOption
-  const fps = 1000 / wait
+  const {leading = false} = options,
+    fpsOption = options.fps ?? 30,
+    wait = options.wait ?? 1000 / fpsOption,
+    fps = 1000 / wait
 
   const nextTimeout = useRef<RequestTimeoutHandle | null>(null),
     tailTimeout = useRef<RequestTimeoutHandle | null>(null),

--- a/packages/throttle/src/index.ts
+++ b/packages/throttle/src/index.ts
@@ -12,15 +12,28 @@ import {
   RequestTimeoutHandle,
 } from '@essentials/request-timeout'
 
+export interface ThrottleOptions {
+  fps?: number
+  leading?: boolean
+}
+
+export interface ThrottleOptions {
+  wait?: number
+  leading?: boolean
+}
+
 export const useThrottleCallback = <CallbackArgs extends any[]>(
   callback: (...args: CallbackArgs) => any,
-  fps = 30,
-  leading = false
+  options: ThrottleOptions = {}
 ): ((...args: CallbackArgs) => void) => {
+  const {leading = false} = options
+  const fpsOption = options.fps ?? 30
+  const wait = options.wait ?? 1000 / fpsOption
+  const fps = 1000 / wait
+
   const nextTimeout = useRef<RequestTimeoutHandle | null>(null),
     tailTimeout = useRef<RequestTimeoutHandle | null>(null),
-    calledLeading = useRef<boolean>(false),
-    wait = 1000 / fps
+    calledLeading = useRef<boolean>(false)
 
   // cleans up pending timeouts when the function changes
   useEffect(
@@ -76,11 +89,10 @@ export const useThrottleCallback = <CallbackArgs extends any[]>(
 
 export const useThrottle = <State>(
   initialState: State | (() => State),
-  fps?: number,
-  leading?: boolean
+  options?: ThrottleOptions
 ): [State, Dispatch<SetStateAction<State>>] => {
   const [state, setState] = useState<State>(initialState)
-  return [state, useThrottleCallback(setState, fps, leading)]
+  return [state, useThrottleCallback(setState, options)]
 }
 
 export default useThrottle

--- a/packages/window-size/README.md
+++ b/packages/window-size/README.md
@@ -66,7 +66,7 @@ const Component = props => {
 | initialHeight   | `number`          |         | The initial width to use when there is no `window` object                                                                 |
 | debounceOptions | `DebounceOptions` |         | Options object passed to the [`useDebounce`](https://github.com/jaredLunde/react-hook/tree/master/packages/debounce) hook |
 
-#### DebounceOptions
+##### DebounceOptions
 
 | Key     | Type      | Default | Description                                                                                                               |
 | ------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
@@ -91,7 +91,7 @@ const Component = props => {
 | initialWidth    | `number`          |         | The initial width to use when there is no `window` object                                                                 |
 | debounceOptions | `DebounceOptions` |         | Options object passed to the [`useDebounce`](https://github.com/jaredLunde/react-hook/tree/master/packages/debounce) hook |
 
-#### DebounceOptions
+##### DebounceOptions
 
 | Key     | Type      | Default | Description                                                                                                               |
 | ------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
@@ -115,7 +115,7 @@ const Component = props => {
 | initialHeight   | `number`          |         | The initial width to use when there is no `window` object                                                                 |
 | debounceOptions | `DebounceOptions` |         | Options object passed to the [`useDebounce`](https://github.com/jaredLunde/react-hook/tree/master/packages/debounce) hook |
 
-#### DebounceOptions
+##### DebounceOptions
 
 | Key     | Type      | Default | Description                                                                                                               |
 | ------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
@@ -144,7 +144,7 @@ To use these throttled hooks instead of debounced hooks, import with `import {..
 | initialHeight   | `number`          |         | The initial width to use when there is no `window` object                                                                 |
 | throttleOptions | `ThrottleOptions` |         | Options object passed to the [`useThrottle`](https://github.com/jaredLunde/react-hook/tree/master/packages/throttle) hook |
 
-#### ThrottleOptions
+##### ThrottleOptions
 
 | Key     | Type      | Default | Description                                                                                                               |
 | ------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
@@ -169,7 +169,7 @@ To use these throttled hooks instead of debounced hooks, import with `import {..
 | initialWidth    | `number`          |         | The initial width to use when there is no `window` object                                                                 |
 | throttleOptions | `ThrottleOptions` |         | Options object passed to the [`useThrottle`](https://github.com/jaredLunde/react-hook/tree/master/packages/throttle) hook |
 
-#### ThrottleOptions
+##### ThrottleOptions
 
 | Key     | Type      | Default | Description                                                                                                               |
 | ------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
@@ -193,7 +193,7 @@ To use these throttled hooks instead of debounced hooks, import with `import {..
 | initialHeight   | `number`          |         | The initial width to use when there is no `window` object                                                                 |
 | throttleOptions | `ThrottleOptions` |         | Options object passed to the [`useThrottle`](https://github.com/jaredLunde/react-hook/tree/master/packages/throttle) hook |
 
-#### ThrottleOptions
+##### ThrottleOptions
 
 | Key     | Type      | Default | Description                                                                                                               |
 | ------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Hey!
I use your awesome hooks more and more. I like it, but today I found an issue in my code when I use `useThrottleCallback` and `useDebounceCallback`. Here is an example:
```typescript
const debounceForSecond          = useDebounceCallback(cb, 1000)
const callNoMoreThatOnceInSecond = useThrottleCallback(cb, 1000)
```
There are bug, because `useThrottleCallback` receive `fps` and not `wait` in miliseconds.

That code looks better:
```typescript
const debounceForSecond          = useDebounceCallback(cb, {wait: 1000})
const callNoMoreThatOnceInSecond = useThrottleCallback(cb, {fps: 1})
```

I started writing PR to receive options or number in second argument, but it looks strange:
```diff
+export function useDebounceCallback<CallbackArgs extends any[]>(
+  callback: (...args: CallbackArgs) => any,
+  options?: { wait?: number; leading?: boolean },
+): ((...args: CallbackArgs) => void);
+export function useDebounceCallback<CallbackArgs extends any[]>(
+  callback: (...args: CallbackArgs) => any,
+  wait?: number,
+  leading?: boolean
+): ((...args: CallbackArgs) => void);
-export const useDebounceCallback = <CallbackArgs extends any[]>(
+export function useDebounceCallback<CallbackArgs extends any[]>(
   callback: (...args: CallbackArgs) => any,
-  wait = 100,
-  leading = false
-): ((...args: CallbackArgs) => void) => {
+  waitOrOptions?: { wait?: number; leading?: boolean } | number,
+  leadingIfNoOptions?: boolean,
+): ((...args: CallbackArgs) => void) {
+  const wait = (typeof waitOrOptions === 'number' ? waitOrOptions : (waitOrOptions?.wait)) ?? 100;
+  const leading = (typeof waitOrOptions === 'number' ? leadingIfNoOptions : waitOrOptions?.leading) ?? false;
+
   const timeout = useRef<RequestTimeoutHandle | null>(null)
```

So that's why I suggest to make breaking changes.

Also, I saw you already did some steps in this direction in [window-size/README.md](https://github.com/jaredLunde/react-hook/blob/master/packages/window-size/README.md#L67) file. I can create a new PR to make it true after this changes publish, in case you argre with my changes.