### PR TITLE
Fix ref return type

### DIFF
--- a/packages/hover/README.md
+++ b/packages/hover/README.md
@@ -54,7 +54,7 @@ const Component = props => {
 | Variable   | Type                             | Description                                                                                                                                               |
 | ---------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | isHovering | `boolean`                        | `true` if the element in `ref` is in a hover state, otherwise `false`. This value is always `false` on devices that don't have hover states, i.e. phones. |
-| ref        | `(element: HTMLElement) => void` | Provide this `ref` to the React element whose hover state you want to observe                                                                             |
+| ref        | `(element: HTMLElement | null) => void` | Provide this `ref` to the React element whose hover state you want to observe                                                                             |
 
 ## LICENSE
 

--- a/packages/hover/src/index.ts
+++ b/packages/hover/src/index.ts
@@ -11,7 +11,7 @@ type EffectReturn = void | (() => void)
 const useHover = (
   enterDelay?: number,
   leaveDelay?: number
-): [boolean, (element: HTMLElement) => void] => {
+): [boolean, (element: HTMLElement | null) => void] => {
   const [isHovering, setHovering] = useState<boolean>(false)
   const timeout = useRef<number | undefined>()
   const [element, setElement] = useState<HTMLElement | null>(null)

--- a/packages/mouse-position/README.md
+++ b/packages/mouse-position/README.md
@@ -62,7 +62,7 @@ const Component = props => {
 | leaveDelay | `number` | `0`     | The amount of time in `ms` to wait after a final action before setting `mouseleave` events to state   |
 | fps        | `number` | `30`    | The rate in frames-per-second that the state should update                                            |
 
-#### Returns `[state: MousePosition, ref: (element: HTMLElement) => void]`
+#### Returns `[state: MousePosition, ref: (element: HTMLElement | null) => void]`
 
 | Variable | Description                                                                               |
 | -------- | ----------------------------------------------------------------------------------------- |

--- a/packages/mouse-position/src/index.ts
+++ b/packages/mouse-position/src/index.ts
@@ -47,7 +47,7 @@ export const useMousePosition = (
   enterDelay = 0,
   leaveDelay = 0,
   fps = 30
-): [MousePosition, (element: HTMLElement) => void] => {
+): [MousePosition, (element: HTMLElement | null) => void] => {
   const [state, setState] = useState<MousePosition>(initialState)
   const [entered, setEntered] = useState<boolean>(false)
   const touchEnded = useRef<boolean>(false)


### PR DESCRIPTION
`hover` mentioned in #18 but `mouse-position` also needed it.

Just curious, is there a reason the return type wouldn't be `React.Dispatch<React.SetStateAction<HTMLElement | null>>`?