### PR TITLE
Various fixes and improvements for mouse-position

### DIFF
--- a/packages/mouse-position/README.md
+++ b/packages/mouse-position/README.md
@@ -32,7 +32,7 @@ hook also provides an interop between touch and desktop devices and will treat
 ```jsx harmony
 import useMousePosition from '@react-hook/mouse-position'
 
-const Component = props => {
+const Component = (props) => {
   const [mousePosition, ref] = useMousePosition(
     0, // enterDelay
     0, // leaveDelay
@@ -85,6 +85,7 @@ const Component = props => {
 | elementHeight | `number`  | `null`  | `DOMRect.height` of the element, `null` if mouse is not over the element                          |
 | isOver        | `boolean` | `false` | `true` if the mouse is currently hovering over the element                                        |
 | isDown        | `boolean` | `false` | `true` if the mouse is currently hovering over the element AND is down                            |
+| isTouch       | `boolean` | `false` | `true` if the the last event was triggered by a touch event                                       |
 
 ## LICENSE
 

--- a/packages/mouse-position/src/index.ts
+++ b/packages/mouse-position/src/index.ts
@@ -21,6 +21,7 @@ export interface MousePosition {
   elementHeight: number | null
   isOver: boolean
   isDown: boolean
+  isTouch: boolean
 }
 
 const initialState: MousePosition = {
@@ -36,6 +37,7 @@ const initialState: MousePosition = {
   elementHeight: null,
   isOver: false,
   isDown: false,
+  isTouch: false
 }
 
 const batchUpdates =
@@ -91,6 +93,7 @@ export const useMousePosition = (
           elementHeight: rect.height,
           isOver: true,
           isDown: prev.isDown,
+          isTouch
         }))
       },
       [element]
@@ -101,7 +104,7 @@ export const useMousePosition = (
 
   useEffect((): void | (() => void) => {
     if (element !== null) {
-      const setDown = (): void => setState((prev) => ({...prev, isDown: true}))
+      const setDown = (evt: MouseEvent | TouchEvent, isTouch = false): void => setState((prev) => ({...prev, isDown: true, isTouch}))
       const onMove = (e: MouseEvent): void => {
         if (!touchEnded.current) {
           batchUpdates(() => {
@@ -123,7 +126,7 @@ export const useMousePosition = (
       const onUp = (): void => setState((prev) => ({...prev, isDown: false}))
       const onTouchStart = (e: TouchEvent): void => {
         touchEnded.current = false
-        setDown()
+        setDown(e, true)
         onDown(e)
       }
       const onTouchMove = (e: TouchEvent): void => {

--- a/packages/mouse-position/src/index.ts
+++ b/packages/mouse-position/src/index.ts
@@ -122,6 +122,7 @@ export const useMousePosition = (
       const onUp = (): void => setState(prev => ({...prev, isDown: false}))
       const onTouchStart = (e: MouseEvent): void => {
         touchEnded.current = false
+        setDown()
         onDown(e)
       }
       const onTouchMove = (e: MouseEvent): void => {

--- a/packages/mouse-position/src/index.ts
+++ b/packages/mouse-position/src/index.ts
@@ -101,7 +101,7 @@ export const useMousePosition = (
 
   useEffect((): void | (() => void) => {
     if (element !== null) {
-      const setDown = (): void => setState(prev => ({...prev, isDown: true}))
+      const setDown = (): void => setState((prev) => ({...prev, isDown: true}))
       const onMove = (e: MouseEvent): void => {
         if (!touchEnded.current) {
           batchUpdates(() => {
@@ -113,13 +113,14 @@ export const useMousePosition = (
       const onLeave = (): void => setEntered(false)
       const onDown = (e: MouseEvent | TouchEvent): void => {
         if (!touchEnded.current) {
+          onMoveCallback(e)
           batchUpdates(() => {
             setEntered(true)
             onMoveCallback(e)
           })
         }
       }
-      const onUp = (): void => setState(prev => ({...prev, isDown: false}))
+      const onUp = (): void => setState((prev) => ({...prev, isDown: false}))
       const onTouchStart = (e: TouchEvent): void => {
         touchEnded.current = false
         setDown()

--- a/packages/mouse-position/src/index.ts
+++ b/packages/mouse-position/src/index.ts
@@ -111,7 +111,7 @@ export const useMousePosition = (
         }
       }
       const onLeave = (): void => setEntered(false)
-      const onDown = (e: MouseEvent): void => {
+      const onDown = (e: MouseEvent | TouchEvent): void => {
         if (!touchEnded.current) {
           batchUpdates(() => {
             setEntered(true)
@@ -120,12 +120,12 @@ export const useMousePosition = (
         }
       }
       const onUp = (): void => setState(prev => ({...prev, isDown: false}))
-      const onTouchStart = (e: MouseEvent): void => {
+      const onTouchStart = (e: TouchEvent): void => {
         touchEnded.current = false
         setDown()
         onDown(e)
       }
-      const onTouchMove = (e: MouseEvent): void => {
+      const onTouchMove = (e: TouchEvent): void => {
         touchEnded.current = false
         onMoveCallback(e)
       }
@@ -181,7 +181,7 @@ export const useMousePosition = (
 
       setActive(false)
     }
-  }, [entered])
+  }, [entered, enterDelay, leaveDelay])
 
   return [active ? state : initialState, setElement]
 }


### PR DESCRIPTION
This PR does a few things that are unrelated. I can split it into several PRs if needed.

There are 2 bug fixes

- Corrects faulty behavior where `isDown` is never true on mobile
- Corrects faulty behavior where it was impossible to obtain the initial x and y coordinates of a drag

There is 1 commit that fixes some type and tslint issues.

Finally, there's a commit that exposes `isTouch` to users, which is sometimes necessary for cross platform UIs.