### PR TITLE
fix(types): fixes #53

### DIFF
--- a/packages/size/src/index.tsx
+++ b/packages/size/src/index.tsx
@@ -37,10 +37,10 @@ const useSize = <T extends HTMLElement>(
 export interface UseSizeOptions {
   // The initial width to set into state.
   // This is useful for SSR environments.
-  initialWidth: 0
+  initialWidth: number
   // The initial height to set into state.
   // This is useful for SSR environments.
-  initialHeight: 0
+  initialHeight: number
 }
 
 export default useSize


### PR DESCRIPTION
### Description

This fixes issue #53 (**useSize initialWidth and initialHeight types**) by setting the type of `initialWidth` and `initialHeight` to `number` instead of `0` in the `size` package.

### Testing

All tests pass.

### Closing issues

Closes #53 .
