### PR TITLE
fix(switch): make sure controlled value updates correctly when changed from outside

### DIFF
--- a/packages/switch/src/index.tsx
+++ b/packages/switch/src/index.tsx
@@ -21,8 +21,9 @@ function useSwitch(
   useChange(current, onChange)
 
   React.useEffect(() => {
-    if (controlledValue === current) return
+    if (!isBoolean(controlledValue) || controlledValue === current) return
     setCurrent(!!controlledValue)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [controlledValue])
 
   return [
@@ -43,6 +44,9 @@ function useSwitch(
   ] as const
 }
 
+function isBoolean(val?: boolean) {
+  return val === false || val === true
+}
 const emptyArr: [] = []
 function noop() {}
 

--- a/packages/switch/src/index.tsx
+++ b/packages/switch/src/index.tsx
@@ -21,7 +21,8 @@ function useSwitch(
   useChange(current, onChange)
 
   React.useEffect(() => {
-    if (!isBoolean(controlledValue) || controlledValue === current) return
+    if (typeof controlledValue !== 'boolean' || controlledValue === current)
+      return
     setCurrent(!!controlledValue)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [controlledValue])
@@ -44,9 +45,6 @@ function useSwitch(
   ] as const
 }
 
-function isBoolean(val?: boolean) {
-  return val === false || val === true
-}
 const emptyArr: [] = []
 function noop() {}
 

--- a/packages/switch/src/index.tsx
+++ b/packages/switch/src/index.tsx
@@ -20,11 +20,16 @@ function useSwitch(
   const [current, setCurrent] = React.useState(controlledValue ?? defaultValue)
   useChange(current, onChange)
 
+  React.useEffect(() => {
+    if (controlledValue === current) return
+    setCurrent(!!controlledValue)
+  }, [controlledValue])
+
   return [
     controlledValue ?? current,
     Object.assign(
       useCallback(
-        () => setCurrent((curr) => !curr),
+        () => setCurrent((curr: boolean) => !curr),
         // eslint-disable-next-line react-hooks/exhaustive-deps
         emptyArr
       ),


### PR DESCRIPTION
Hi Jared,

I opened an issue before on @accessible/checkbox: see https://github.com/accessible-ui/checkbox/issues/6
But the issue seems in fact to do with useSwitch. When useSwitch is updated I can make a pr for the checkbox.

I demonstrate the issue in the codesandbox: https://codesandbox.io/s/react-hookswitch-issue-demo-1d9yy

Steps to reproduce issue:
1. Control the controlled value from outside by clicking on the 'toggle from outside' button
2. See the value in the Switch Component change correctly to true
3. Then press 'SwitchComponent Toggle' button
4. See how it doesnt change to false because the controlled value inside useSwitch wasnt updated correctly when the value was changed from outside


thnx!