### PR TITLE
docs(latest): Remove untracked dependency in readme example

### DIFF
--- a/packages/latest/README.md
+++ b/packages/latest/README.md
@@ -40,7 +40,7 @@ const useEvent = (element, name, listener) => {
     const listen = (e) => latest.current(e)
     element.addEventListener(name, listen)
     return () => element.removeEventListener(name, listen)
-  }, [latest])
+  }, [])
 }
 ```
 


### PR DESCRIPTION
I am sorry for not opening an issue.

Adding a `MutableRefObject` as a `useEffect` dependency has no effect :)  
So I changed I added a very tiny change to the readme of `useLatest`.
