### PR TITLE
[resize-observer] Fixes #122, replaces unmaintained resize-observer-polyfill with @juggle/resize-observer

### DIFF
--- a/packages/resize-observer/package.json
+++ b/packages/resize-observer/package.json
@@ -126,11 +126,11 @@
     "typescript": "latest"
   },
   "dependencies": {
+    "@juggle/resize-observer": "^3.3.1",
     "@react-hook/latest": "^1.0.2",
     "@react-hook/passive-layout-effect": "^1.2.0",
     "@types/raf-schd": "^4.0.0",
-    "raf-schd": "^4.0.2",
-    "resize-observer-polyfill": "^1.5.1"
+    "raf-schd": "^4.0.2"
   },
   "peerDependencies": {
     "react": ">=16.8"

--- a/packages/resize-observer/src/index.tsx
+++ b/packages/resize-observer/src/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import ResizeObserver from 'resize-observer-polyfill'
+import {ResizeObserver, ResizeObserverEntry} from '@juggle/resize-observer'
 import useLayoutEffect from '@react-hook/passive-layout-effect'
 import useLatest from '@react-hook/latest'
 import rafSchd from 'raf-schd'

--- a/packages/resize-observer/types/index.d.ts
+++ b/packages/resize-observer/types/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import ResizeObserver from 'resize-observer-polyfill'
+import {ResizeObserver, ResizeObserverEntry} from '@juggle/resize-observer'
 /**
  * A React hook that fires a callback whenever ResizeObserver detects a change to its size
  *

--- a/packages/resize-observer/yarn.lock
+++ b/packages/resize-observer/yarn.lock
@@ -1205,6 +1205,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@juggle/resize-observer@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.3.1.tgz#b50a781709c81e10701004214340f25475a171a0"
+  integrity sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==
+
 "@lunde/babel-preset-es@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@lunde/babel-preset-es/-/babel-preset-es-1.0.1.tgz#78f13276b8c4ca2e1032afa476c79b0fc9184a86"
@@ -5690,11 +5695,6 @@ requireindex@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
   integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
-
-resize-observer-polyfill@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
-  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
As discussed in https://github.com/jaredLunde/react-hook/issues/122. 

The `react-hook/size` package does not have the dependency itself but instead depends on `react-hook/resize-observer` so these changes should be enough.

Let me know if anything is missing or should be changed! ✌🏼 