### PR TITLE
[resize-observer] fix: Unobserve target only when last callback is unsubscribing

### DIFF
--- a/packages/resize-observer/src/index.tsx
+++ b/packages/resize-observer/src/index.tsx
@@ -70,9 +70,9 @@ function createResizeObserver() {
       callbacks.set(target, cbs)
     },
     unsubscribe(target: HTMLElement, callback: UseResizeObserverCallback) {
-      observer.unobserve(target)
       const cbs = callbacks.get(target) ?? []
       if (cbs.length === 1) {
+        observer.unobserve(target)
         callbacks.delete(target)
         return
       }


### PR DESCRIPTION
This PR fixes wrong unobserving: at the moment it happens when any of callbacks is unsubscribing, but it should be done only when the last callback is unsubscribing, otherwise it breaks observation for other subscribers