### PR TITLE
[resize-observer] fix: invoke callback on all entries

### DIFF
--- a/packages/resize-observer/package.json
+++ b/packages/resize-observer/package.json
@@ -128,9 +128,7 @@
   "dependencies": {
     "@juggle/resize-observer": "^3.3.1",
     "@react-hook/latest": "^1.0.2",
-    "@react-hook/passive-layout-effect": "^1.2.0",
-    "@types/raf-schd": "^4.0.0",
-    "raf-schd": "^4.0.2"
+    "@react-hook/passive-layout-effect": "^1.2.0"
   },
   "peerDependencies": {
     "react": ">=16.8"

--- a/packages/resize-observer/yarn.lock
+++ b/packages/resize-observer/yarn.lock
@@ -1523,11 +1523,6 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/raf-schd@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/raf-schd/-/raf-schd-4.0.0.tgz#0f3f7a68aa385cc0eb52d257b56fe526134261ff"
-  integrity sha512-EsXE+pu4MjOhU+H2Ut/8zOGUtictm87anwxOcNY1HjxkH8ipLR+SzYnCzT4lQvyKJdcMwIGxhb8w/KZhOy6vaQ==
-
 "@types/react-dom@latest":
   version "16.9.8"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
@@ -5416,11 +5411,6 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-
-raf-schd@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.2.tgz#bd44c708188f2e84c810bf55fcea9231bcaed8a0"
-  integrity sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ==
 
 randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
This PR provides a fix for #217. The main issue was that with RAF-based throttling only the last resized entries are being invoked with their respective callback functions. To invoke the callback functions for _all_ entries that have resized during an animation frame the ResizeObserver's callback function contains two parts: an unthrottled part that accumulates all resized entries and a RAF-throttled part that invokes the callback functions on all the accumulated entries.

I am happy to adjust the PR as needed. The main reason I've set it up right away is to make testing of my proposed solution easier/faster.

### Testing

I can confirm that the following existing test still passes:

```tsx
describe('useResizeObserver()', () => {
  it('should pass', () => {
    expect(true).toBe(true)
  })
})
```

### Closing issues

Closes #217 
