### PR TITLE
Fix deprecated mapping in exports field

### DIFF
--- a/packages/async/package.json
+++ b/packages/async/package.json
@@ -44,7 +44,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -41,7 +41,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/change/package.json
+++ b/packages/change/package.json
@@ -36,7 +36,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/click/package.json
+++ b/packages/click/package.json
@@ -39,7 +39,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/copy/package.json
+++ b/packages/copy/package.json
@@ -37,7 +37,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/counter/package.json
+++ b/packages/counter/package.json
@@ -34,7 +34,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/debounce/package.json
+++ b/packages/debounce/package.json
@@ -40,7 +40,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/event/package.json
+++ b/packages/event/package.json
@@ -39,7 +39,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/google-optimize/package.json
+++ b/packages/google-optimize/package.json
@@ -42,7 +42,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/hotkey/package.json
+++ b/packages/hotkey/package.json
@@ -46,7 +46,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/hover/package.json
+++ b/packages/hover/package.json
@@ -38,7 +38,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/intersection-observer/package.json
+++ b/packages/intersection-observer/package.json
@@ -39,7 +39,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/latest/package.json
+++ b/packages/latest/package.json
@@ -36,7 +36,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/media-query/package.json
+++ b/packages/media-query/package.json
@@ -44,7 +44,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/merged-ref/package.json
+++ b/packages/merged-ref/package.json
@@ -42,7 +42,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/mouse-position/package.json
+++ b/packages/mouse-position/package.json
@@ -42,7 +42,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/passive-layout-effect/package.json
+++ b/packages/passive-layout-effect/package.json
@@ -34,7 +34,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/previous/package.json
+++ b/packages/previous/package.json
@@ -37,7 +37,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/resize-observer/package.json
+++ b/packages/resize-observer/package.json
@@ -39,7 +39,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/server-promises/package.json
+++ b/packages/server-promises/package.json
@@ -35,7 +35,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/size/package.json
+++ b/packages/size/package.json
@@ -37,7 +37,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -40,7 +40,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/throttle/package.json
+++ b/packages/throttle/package.json
@@ -40,7 +40,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/timeout/package.json
+++ b/packages/timeout/package.json
@@ -36,7 +36,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/toggle/package.json
+++ b/packages/toggle/package.json
@@ -35,7 +35,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/window-scroll/package.json
+++ b/packages/window-scroll/package.json
@@ -48,7 +48,7 @@
       "default": "./dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/window-size/package.json
+++ b/packages/window-size/package.json
@@ -67,7 +67,7 @@
       "default": "./throttled/dist/main/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "sideEffects": false,
   "scripts": {


### PR DESCRIPTION
Fixes https://github.com/jaredLunde/react-hook/issues/275

This is a change for all packages to avoid the deprecated folder mapping in the `exports` field of `package.json` .
Note that this will break path imports for Node.js v12 and earlier (v12 end of life was October 2020). There's some related discussion of that here: https://github.com/postcss/postcss/pull/1456


