### PR TITLE
[resize-observer] Improve type compatibility with React's forwardRef

### DIFF
--- a/packages/resize-observer/src/index.tsx
+++ b/packages/resize-observer/src/index.tsx
@@ -22,7 +22,7 @@ const ResizeObserver =
  *   the `target` resizes
  */
 function useResizeObserver<T extends HTMLElement>(
-  target: React.RefObject<T> | T | null,
+  target: React.RefObject<T> | React.ForwardedRef<T> | T | null,
   callback: UseResizeObserverCallback
 ): Polyfill {
   const resizeObserver = getResizeObserver()

--- a/packages/resize-observer/types/index.d.ts
+++ b/packages/resize-observer/types/index.d.ts
@@ -11,7 +11,7 @@ import {
  *   the `target` resizes
  */
 declare function useResizeObserver<T extends HTMLElement>(
-  target: React.RefObject<T> | T | null,
+  target: React.RefObject<T> | React.ForwardedRef<T> | T | null,
   callback: UseResizeObserverCallback
 ): Polyfill
 export declare type UseResizeObserverCallback = (


### PR DESCRIPTION
**Description**

* **What does this implement/fix? Explain your changes.**
    * This change addresses a type inference issue when using the `useResizeObserver` hook in conjunction with components created using `React.forwardRef`.  Specifically, it eliminates the need to explicitly cast refs. 
    * Briefly describe the change:  I modified the `target` argument type in the `useResizeObserver` hook to accept `React.RefObject<T> | React.ForwardedRef<T> | T | null`.

* **Testing**
    * I have tested this change with my existing components using `forwardRef`, and the types now infer correctly. I'm confident this doesn't introduce regressions.

**Closing Issues**
* This fixes an open issue, Closes #304