### PR TITLE
[resize-observer] fix: Accept non-HTML elements

### DIFF
--- a/packages/resize-observer/README.md
+++ b/packages/resize-observer/README.md
@@ -75,7 +75,7 @@ const App = () => {
 ### useResizeObserver(target, callback)
 
 ```ts
-function useResizeObserver<T extends HTMLElement>(
+function useResizeObserver<T extends Element>(
   target: React.RefObject<T> | T | null,
   callback: UseResizeObserverCallback
 ): ResizeObserver

--- a/packages/resize-observer/src/index.tsx
+++ b/packages/resize-observer/src/index.tsx
@@ -21,7 +21,7 @@ const ResizeObserver =
  * @param callback Invoked with a single `ResizeObserverEntry` any time
  *   the `target` resizes
  */
-function useResizeObserver<T extends HTMLElement>(
+function useResizeObserver<T extends Element>(
   target: React.RefObject<T> | T | null,
   callback: UseResizeObserverCallback
 ): Polyfill {
@@ -38,11 +38,11 @@ function useResizeObserver<T extends HTMLElement>(
       storedCallback.current(entry, observer)
     }
 
-    resizeObserver.subscribe(targetEl as HTMLElement, cb)
+    resizeObserver.subscribe(targetEl as Element, cb)
 
     return () => {
       didUnsubscribe = true
-      resizeObserver.unsubscribe(targetEl as HTMLElement, cb)
+      resizeObserver.unsubscribe(targetEl as Element, cb)
     }
   }, [target, resizeObserver, storedCallback])
 
@@ -77,13 +77,13 @@ function createResizeObserver() {
 
   return {
     observer,
-    subscribe(target: HTMLElement, callback: UseResizeObserverCallback) {
+    subscribe(target: Element, callback: UseResizeObserverCallback) {
       observer.observe(target)
       const cbs = callbacks.get(target) ?? []
       cbs.push(callback)
       callbacks.set(target, cbs)
     },
-    unsubscribe(target: HTMLElement, callback: UseResizeObserverCallback) {
+    unsubscribe(target: Element, callback: UseResizeObserverCallback) {
       const cbs = callbacks.get(target) ?? []
       if (cbs.length === 1) {
         observer.unobserve(target)

--- a/packages/resize-observer/types/index.d.ts
+++ b/packages/resize-observer/types/index.d.ts
@@ -10,7 +10,7 @@ import {
  * @param callback Invoked with a single `ResizeObserverEntry` any time
  *   the `target` resizes
  */
-declare function useResizeObserver<T extends HTMLElement>(
+declare function useResizeObserver<T extends Element>(
   target: React.RefObject<T> | T | null,
   callback: UseResizeObserverCallback
 ): Polyfill


### PR DESCRIPTION
This change is pretty self-explanatory. `ResizeObserver` accepts `Element`, while `useResizeObserver` only accepts `HTMLElement`. This PR widens the type to `Element`, so that all element types (e.g. `<svg/>`) can be observed too.

Fixes/Closes #306.