### PR TITLE
Minor tweaks to resize-observer

### DIFF
--- a/packages/resize-observer/README.md
+++ b/packages/resize-observer/README.md
@@ -70,12 +70,13 @@ const App = () => {
 
 ## API
 
-### useResizeObserver(target, callback)
+### useResizeObserver(target, callback, options)
 
 ```ts
 function useResizeObserver<T extends Element>(
-  target: React.RefObject<T> | T | null,
-  callback: UseResizeObserverCallback
+  target: React.RefObject<T> | React.ForwardedRef<T> | T | null,
+  callback: UseResizeObserverCallback,
+  options?: UseResizeObserverOptions
 ): ResizeObserver
 ```
 
@@ -99,9 +100,22 @@ export type UseResizeObserverCallback = (
 ### UseResizeObserverOptions
 
 ```ts
-expo
+export type UseResizeObserverOptions = {
+  polyfill?: any
+}
+```
+
+#### `polyfill`
+
+A `ResizeObserver` polyfill implementation such as `@juggle/resize-observer` (this was the default in V1.x).
+
+```ts
+import useResizeObserver from '@react-hook/resize-observer'
+import {ResizeObserver} from '@juggle/resize-observer'
+
+useResizeObserver(..., ..., { polyfill: ResizeObserver })
+```
 
 ## LICENSE
 
 MIT
-```

--- a/packages/resize-observer/package.json
+++ b/packages/resize-observer/package.json
@@ -131,7 +131,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@juggle/resize-observer": "^3.3.1",
     "@react-hook/latest": "^1.0.2",
     "@react-hook/passive-layout-effect": "^1.2.0"
   },

--- a/packages/resize-observer/yarn.lock
+++ b/packages/resize-observer/yarn.lock
@@ -2200,11 +2200,6 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@juggle/resize-observer@^3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.3.1.tgz#b50a781709c81e10701004214340f25475a171a0"
-  integrity sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==
-
 "@lunde/babel-preset-es@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@lunde/babel-preset-es/-/babel-preset-es-1.0.1.tgz#78f13276b8c4ca2e1032afa476c79b0fc9184a86"


### PR DESCRIPTION
This PR makes two small changes to `resize-observer` following the 2.x release:

- Remove the dependency on `@juggle/resize-observer`, which is no longer used.
- Update the README documentation to describe the new `polyfill` option.

Thanks!
