### PR TITLE
[resize-observer] Fixes #312 - use observer `disconnect` 

### DIFF
--- a/packages/resize-observer/src/index.tsx
+++ b/packages/resize-observer/src/index.tsx
@@ -33,7 +33,7 @@ function useResizeObserver<T extends Element>(
 
     return () => {
       didUnsubscribe = true
-      resizeObserver.unsubscribe(targetEl as Element, cb)
+      resizeObserver.disconnect()
     }
   }, [target, resizeObserver, storedCallback])
 


### PR DESCRIPTION
`disconnect` is the safest option when the component unmounts since there might not be a DOM node in existence any longer to apply `unsubscribe` to:

https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/disconnect


### Please provide enough information so that others can review your pull request

- What does this implement/fix? Explain your changes.
- Does this close any currently open issues?
- Include the package name or names you're updating in your PR title, e.g. `[async] Fixes #129`, `[debounce, throttle] Updates build scripts` 

### Testing

No need for new tests, as existing ones should covers it

### Closing issue #312


